### PR TITLE
add SOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,21 @@ It comes with a window manager as well as basic applications like an
 - **intermezzOS**       ([repository](https://github.com/intermezzos/kernel) / [homepage](http://intermezzos.github.io/))
 - **Quasar**            ([repository](https://github.com/LeoTestard/Quasar))
 - **Tock**              ([repository](https://github.com/helena-project/tock) / [homepage](http://www.tockos.org/))
+- **SOS**               ([repository](https://github.com/hawkw/sos-kernel))
 
 
-|                         Name | redox              | reenix                                                | rustboot | RustOS       | RustOS       | Tifflin        | bkernel                    | intermezzOS   | Quasar      | Tock        |
-| ---------------------------- | ------------------ |------------------------------------------------------ | -------- | ------------ | ------------ | -------------- | -------------------------- | --------------| ------------| ------------|
-|            **Architectures** | x86 and x86_64     | [Brown's CS167/9](http://cs.brown.edu/courses/cs167/) | i386     | i386         | i386         | x86_64/amd64   | ARM                        | x86_64        | x86_64      | Cortex M    |
-| **Pure Rust implementation** | yes                | no                                                    | ?        | ?            | ?            | *almost*       | yes                        | no            | ?           |             |
-|                  **Active?** | yes                | no                                                    | no       | yes          | yes          | yes            | yes                        | yes           | no          | yes         |
-|      **Kernel architecture** | Microkernel        | Monolithic (current state)                            | None     | None         | None         | Monolithic     | ?                          | ?             | ?           |             |
-|                   **Target** | General purpose    | PoC                                                   | PoC      | PoC          | PoC          | ?              | Embedded devices           | PoC           | ?           |             |
-|                **Userpace?** | yes                | no                                                    | no       | no           | no           | ?              | no                         | no            | no          |             |
-|            **Optional GUI?** | yes                | no                                                    | no       | no           | no           | yes            | no                         | no            | no          | no          |
-|             **Contributors** | 40+                | 3                                                     | 9        | 10           | 10           | 1              | 3                          | 4             | 1           | 14          |
-|               **Filesystem** | [ZFS](https://github.com/redox-os/zfs)/[RedoxFS](https://github.com/redox-os/redoxfs) | ? | no | no  | ? | no | no  | ISO9660        | ?                          | no            | ?           |             |
-|                  **License** | MIT                | [unknown](https://github.com/scialex/reenix/issues/1) | MIT      | APL 2 / MIT  | APL 2 / MIT  | 2-Clause-BSD   | GPL with linking exception | APL 2 / MIT   | ?           | APL 2 / MIT |
+|                         Name | redox              | reenix                                                | rustboot | RustOS       | RustOS       | Tifflin        | bkernel                    | intermezzOS   | Quasar      | Tock        | SOS        |
+| ---------------------------- | ------------------ |------------------------------------------------------ | -------- | ------------ | ------------ | -------------- | -------------------------- | --------------| ------------| ------------| ------------
+|            **Architectures** | x86 and x86_64     | [Brown's CS167/9](http://cs.brown.edu/courses/cs167/) | i386     | i386         | i386         | x86_64/amd64   | ARM                        | x86_64        | x86_64      | Cortex M    | x86_64
+| **Pure Rust implementation** | yes                | no                                                    | ?        | ?            | ?            | *almost*       | yes                        | no            | ?           |             | yes
+|                  **Active?** | yes                | no                                                    | no       | yes          | yes          | yes            | yes                        | yes           | no          | yes         | yes
+|      **Kernel architecture** | Microkernel        | Monolithic (current state)                            | None     | None         | None         | Monolithic     | ?                          | ?             | ?           |             | Microkernel
+|                   **Target** | General purpose    | PoC                                                   | PoC      | PoC          | PoC          | ?              | Embedded devices           | PoC           | ?           |             | PoC
+|                **Userpace?** | yes                | no                                                    | no       | no           | no           | ?              | no                         | no            | no          |             | no
+|            **Optional GUI?** | yes                | no                                                    | no       | no           | no           | yes            | no                         | no            | no          | no          | no
+|             **Contributors** | 40+                | 3                                                     | 9        | 10           | 10           | 1              | 3                          | 4             | 1           | 14          | 4
+|               **Filesystem** | [ZFS](https://github.com/redox-os/zfs)/[RedoxFS](https://github.com/redox-os/redoxfs) | ? | no | no  | ? | no | no  | ISO9660        | ?                          | no            | ?           |             | ?
+|                  **License** | MIT                | [unknown](https://github.com/scialex/reenix/issues/1) | MIT      | APL 2 / MIT  | APL 2 / MIT  | 2-Clause-BSD   | GPL with linking exception | APL 2 / MIT   | ?           | APL 2 / MIT | MIT
 Also worth noting: [Robigalia](https://github.com/robigalia/sel4-sys), a sel4 userspace, written in Rust.
 
 ## Blog posts and papers


### PR DESCRIPTION
I've taken the liberty of adding my own toy kernel project, SOS. 

While SOS is still very much a work in progress, I think it's noteworthy enough to add to the list, because as far as I know, it's the first working x86_64 kernel implemented in pure Rust. As of hawkw/sos-kernel@f436b2dc25bfa5aba11c6dbffcbd5e058e9cfafd, SOS boots to long mode without a single assembly file in the repo (with a little help from multiboot).

I hope it's not too presumptuous of me to add my own work to the list. Thanks!