### PR TITLE
Added the ParvaOS project

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ It comes with a window manager as well as basic applications like an
 - **Theseus OS**        ([repository](https://github.com/theseus-os/Theseus) / [homepage](https://www.theseus-os.com/))
 - **Tock**              ([repository](https://github.com/helena-project/tock) / [homepage](http://www.tockos.org/))
 - **intermezzOS**       ([repository](https://github.com/intermezzos/kernel) / [homepage](http://intermezzos.github.io/))
-- **reenix**            ([repository](https://github.com/scialex/reenix))
+- **ParvaOS**
+([repository](https://github.com/gianndev/ParvaOS))
+- **reenix**
+([repository](https://github.com/scialex/reenix))
 - **rustboot**          ([repository](https://github.com/charliesome/rustboot))
 - **RustOS**            ([repository](https://github.com/ryanra/RustOS))
 - **QuiltOS**           ([repository](https://github.com/QuiltOS/QuiltOS))
@@ -34,6 +37,7 @@ It comes with a window manager as well as basic applications like an
 | **Theseus OS**  | x86_64, ARM WIP   | yes       | yes     | Safe-language SAS/SPL OS[^1] | General + Embedded  | N/A       | yes           | 25           | Custom/FAT32            | MIT                        |
 | **Tock**        | Cortex-M, RISC-V, x86 | yes   | yes     | Safe-language SAS/SPL kernel with userspace | embedded  | yes  | no            | 264          |                         | APL 2 / MIT                |
 | **intermezzOS** | x86_64            | no        | yes     | ?                            | PoC                 | no        | no            | 18           | no                      | APL 2 / MIT                |
+| **ParvaOS**     | x86_64            | yes | yes | Monolithic | General purpose | no | yes | 1 | no | GPL-3.0
 | **RustOS**      | i386              | ?         | yes     | None                         | PoC                 | no        | no            | 10           | no                      | APL 2 / MIT                |
 | **rustboot**    | i386              | ?         | no      | None                         | PoC                 | no        | no            | 8            | no                      | MIT                        |
 | **bkernel**     | ARM               | yes       | yes     | ?                            | Embedded devices    | no        | no            | 4            | ?                       | GPL with linking exception |


### PR DESCRIPTION
Hi,
I recently started working on an operating system built entirely in Rust, called ParvaOS and I added my project to the list and table, providing all the necessary references myself. I would be very happy if my changes were accepted and ParvaOS could be part of the beautiful summary README comparing operating systems in Rust that you created.